### PR TITLE
Parse: Make new methods to handle checks

### DIFF
--- a/data/duke.txt
+++ b/data/duke.txt
@@ -1,3 +1,5 @@
 E%% %%upcoming test%%2020-02-19 17:55
 T%% %%read lecture notes
 E%% %%playgames%%2021-02-23 11:55
+E%% %%playgames %%2020-03-19 13:00
+T%% %%playgames

--- a/src/main/java/duke/storage/TaskList.java
+++ b/src/main/java/duke/storage/TaskList.java
@@ -36,7 +36,7 @@ public class TaskList extends ArrayList<Task> {
     }
 
     /**
-     * Add all of the task in the List of String.
+     * Add all the task in the List of String.
      *
      * @param inputString The list of lines of string.
      */

--- a/src/main/java/duke/tasks/Deadline.java
+++ b/src/main/java/duke/tasks/Deadline.java
@@ -24,8 +24,8 @@ public class Deadline extends Task {
 
     @Override
     public String toString() {
-        return '[' + this.taskType + ']' + '[' + getStatusIcon()
-                + ']' + ' ' + this.description
-                + String.format(" (by: %s)", this.time.format(formatter));
+        return String.format("[%s][%s] %s (by: %s)",
+                getTaskType(), getStatusIcon(), getDescription(), getTime()
+        );
     }
 }

--- a/src/main/java/duke/tasks/Event.java
+++ b/src/main/java/duke/tasks/Event.java
@@ -24,7 +24,8 @@ public class Event extends Task {
 
     @Override
     public String toString() {
-        return "[" + this.taskType + "]" + "[" + getStatusIcon() + "]" + " " + this.description
-                + String.format(" (at: %s)", this.time.format(formatter));
+        return String.format("[%s][%s] %s (by: %s)",
+                getTaskType(), getStatusIcon(), getDescription(), getTime()
+        );
     }
 }


### PR DESCRIPTION
Parse method is doing too much and is very long.
Some checks are repeated.

Extracting checks to new methods make the code more readable, shorter,
and follows SLAP more closely.

Let's
- take out the repeated checks out to be done by other methods.
- move some of the processing to new methods.